### PR TITLE
Fix for incorrect GD version detection

### DIFF
--- a/Image/Canvas/GD.php
+++ b/Image/Canvas/GD.php
@@ -1861,9 +1861,9 @@ class Image_Canvas_GD extends Image_Canvas_WithMap
             }
         }
 
-        preg_match('/\d/', $version, $result );
+        preg_match('/(\d+)\./', $version, $result );
+        return $result[1];
 
-        return $result[0];
     }
 
 }


### PR DESCRIPTION
This change fixes:
https://pear.php.net/bugs/bug.php?id=19954

I haven't tested this thoroughly, but it solves the recent problem with GD 2.1.0 (released with PHP 5.4.15) being detected as 1.x

From what I can tell, it should work for all versions just fine though.
