### PR TITLE
Add tests and GitHub actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,29 +35,35 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: none
         ini-values: post_max_size=256M, max_execution_time=180
-    - run: sudo pear list
-    - run: sudo pear channel-update pear.php.net
-    - run: sudo pear upgrade --force pear/pear
-    - run: sudo pear list
-    - run: sudo pear install --force package.xml
-    - run: sudo pear list
-    - run: sudo pear package
-    - run: sudo pear package-validate
-    - run: sudo pear install --force *.tgz
-    - run: sudo pear list
-    # Download and install Verdana font (for some reason ttf-mscorefonts-installer doesn't work)
-    - run: sudo apt install cabextract
-    - run: curl -L -o verdan32.exe 'http://download.sourceforge.net/corefonts/verdan32.exe'
-    - run: cabextract -d Image/Canvas/Fonts/ verdan32.exe
-    - run: mv Image/Canvas/Fonts/Verdana.TTF Image/Canvas/Fonts/verdana.ttf
-    # Install pre-requisites and run test scripts
-    - run: composer install
-    - run: php tests/gradients.php > gradients.png
-    - run: php tests/imagemap.php > imagemap.html
-    - run: php tests/png.php
-    - run: php tests/jpg.php
-    # - run: php tests/ps.php
-    # - run:php tests/pdf.php
-    - run: php tests/svg.php
-    - run: php tests/text.php > text.png
-    - run: php tests/lineends.php > lineends.png
+    - name: Check package
+      run: |
+        sudo pear list
+        sudo pear channel-update pear.php.net
+        sudo pear upgrade --force pear/pear
+        sudo pear list
+        sudo pear install --force package.xml
+        sudo pear list
+        sudo pear package
+        sudo pear package-validate
+        sudo pear install --force *.tgz
+        sudo pear list
+    # For some reason ttf-mscorefonts-installer doesn't work
+    # so we only install Verdana
+    - name: Download and install Verdana font
+      run: |
+        sudo apt install cabextract
+        curl -L -o verdan32.exe 'http://download.sourceforge.net/corefonts/verdan32.exe'
+        cabextract -d Image/Canvas/Fonts/ verdan32.exe
+        mv Image/Canvas/Fonts/Verdana.TTF Image/Canvas/Fonts/verdana.ttf
+    - name: Install pre-requisites and run test scripts
+      run: |
+        composer install
+        php tests/gradients.php > gradients.png
+        php tests/imagemap.php > imagemap.html
+        php tests/png.php
+        php tests/jpg.php
+        # php tests/ps.php
+        # php tests/pdf.php
+        php tests/svg.php
+        php tests/text.php > text.png
+        php tests/lineends.php > lineends.png

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,13 +45,11 @@ jobs:
     - run: sudo pear package-validate
     - run: sudo pear install --force *.tgz
     - run: sudo pear list
-    # Prepare fonts (see https://askubuntu.com/a/25614)
-    - run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-    - run: sudo apt install -y ttf-mscorefonts-installer
-    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdana.ttf Image/Canvas/Fonts/
-    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdanab.ttf Image/Canvas/Fonts/
-    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdanai.ttf Image/Canvas/Fonts/
-    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdanaz.ttf Image/Canvas/Fonts/
+    # Download and install Verdana font (for some reason ttf-mscorefonts-installer doesn't work)
+    - run: sudo apt install cabextract
+    - run: curl -L -o verdan32.exe 'http://download.sourceforge.net/corefonts/verdan32.exe'
+    - run: cabextract -d Image/Canvas/Fonts/ verdan32.exe
+    - run: mv Image/Canvas/Fonts/Verdana.TTF Image/Canvas/Fonts/verdana.ttf
     # Install pre-requisites and run test scripts
     - run: composer install
     - run: php tests/gradients.php > gradients.png

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,65 @@
+name: Main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - release/**
+  pull_request:
+    branches:
+      - main
+      - master
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+    steps:
+    - name: Get source code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none
+        ini-values: post_max_size=256M, max_execution_time=180
+    - run: sudo pear list
+    - run: sudo pear channel-update pear.php.net
+    - run: sudo pear upgrade --force pear/pear
+    - run: sudo pear list
+    - run: sudo pear install --force package.xml
+    - run: sudo pear list
+    - run: sudo pear package
+    - run: sudo pear package-validate
+    - run: sudo pear install --force *.tgz
+    - run: sudo pear list
+    # Prepare fonts (see https://askubuntu.com/a/25614)
+    - run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+    - run: sudo apt install -y ttf-mscorefonts-installer
+    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdana.ttf Image/Canvas/Fonts/
+    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdanab.ttf Image/Canvas/Fonts/
+    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdanai.ttf Image/Canvas/Fonts/
+    - run: sudo cp -rp /usr/share/fonts/truetype/msttcorefonts/verdanaz.ttf Image/Canvas/Fonts/
+    # Install pre-requisites and run test scripts
+    - run: composer install
+    - run: php tests/gradients.php > gradients.png
+    - run: php tests/imagemap.php > imagemap.html
+    - run: php tests/png.php
+    - run: php tests/jpg.php
+    # - run: php tests/ps.php
+    # - run:php tests/pdf.php
+    - run: php tests/svg.php
+    - run: php tests/text.php > text.png
+    - run: php tests/lineends.php > lineends.png

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "type": "library",
     "require": {
+        "php": ">=5.6, < 8.0",
         "pear/pear_exception": "*",
         "pear/image_color": "*"
     }

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,5 @@
     "require": {
         "pear/pear_exception": "*",
         "pear/image_color": "*"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "*"
     }
 }

--- a/tests/canvas_body.php
+++ b/tests/canvas_body.php
@@ -305,11 +305,11 @@ $canvas->polygon(array('connect' => true));
 
 $canvas->addText(array('x' => 375, 'y' => 455, 'text' => 'Image'));
 
-$canvas->image(array('x' => 445, 'y' => 455, 'filename' => './pear-icon.png', 'url' => 'http://pear.veggerby.dk/', 'target' => '_blank'));
+$canvas->image(array('x' => 445, 'y' => 455, 'filename' => __DIR__ . '/pear-icon.png', 'url' => 'http://pear.veggerby.dk/', 'target' => '_blank'));
 
-$canvas->image(array('x' => 445, 'y' => 495, 'filename' => './pear-icon.png', 'width' => 20, 'height' => 20));
+$canvas->image(array('x' => 445, 'y' => 495, 'filename' => __DIR__ . '/pear-icon.png', 'width' => 20, 'height' => 20));
 
-$canvas->image(array('x' => 445, 'y' => 523, 'filename' => './pear-icon.png', 'width' => 40, 'height' => 40));
+$canvas->image(array('x' => 445, 'y' => 523, 'filename' => __DIR__ . '/pear-icon.png', 'width' => 40, 'height' => 40));
 
 //$canvas->show();
 $type = basename($_SERVER['SCRIPT_NAME'], '.php');

--- a/tests/gradients.php
+++ b/tests/gradients.php
@@ -27,7 +27,7 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */  
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory(
     'png', 

--- a/tests/imagemap.php
+++ b/tests/imagemap.php
@@ -27,7 +27,7 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */  
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory(
     'png', 

--- a/tests/jpg.php
+++ b/tests/jpg.php
@@ -30,10 +30,10 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory('jpg', array('width' => 600, 'height' => 600, 'quality' => 90));
 
-require_once './canvas_body.php';
+require_once __DIR__ . '/canvas_body.php';
 
 ?>

--- a/tests/lineends.php
+++ b/tests/lineends.php
@@ -27,7 +27,7 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $font = array('name' => 'Verdana', 'size' => 10);
 

--- a/tests/pdf.php
+++ b/tests/pdf.php
@@ -30,10 +30,10 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory('pdf', array('page' => 'A4', 'align' => 'center', 'width' => 600, 'height' => 600));
 
-require_once './canvas_body.php';
+require_once __DIR__ . '/canvas_body.php';
 
 ?>

--- a/tests/png.php
+++ b/tests/png.php
@@ -30,10 +30,10 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory('png', array('width' => 600, 'height' => 600));
 
-require_once './canvas_body.php';
+require_once __DIR__ . '/canvas_body.php';
 
 ?>

--- a/tests/ps.php
+++ b/tests/ps.php
@@ -30,10 +30,10 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory('ps', array('page' => 'A4', 'align' => 'center', 'width' => 600, 'height' => 600, 'filename'=>'testps.ps'));
 
-require_once './canvas_body.php';
+require_once __DIR__ . '/canvas_body.php';
 
 ?>

--- a/tests/svg.php
+++ b/tests/svg.php
@@ -30,10 +30,10 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory('svg', array('width' => 600, 'height' => 600));
 
-require_once './canvas_body.php';
+require_once __DIR__ . '/canvas_body.php';
 
 ?>

--- a/tests/text.php
+++ b/tests/text.php
@@ -27,7 +27,7 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */
 
-require_once 'Image/Canvas.php';
+require_once 'vendor/autoload.php';
 
 $canvas =& Image_Canvas::factory(
     'png',


### PR DESCRIPTION
This PR modifies the test scripts so they can be run on modern installation. Also it set up github actions.

# Technical details

  - We only test PHP 5.6 to 7.4 because the code is not compatible with PHP 8.
  - We need to install MicroSoft's Verdana font (for test using text). This is legal (see https://corefonts.sourceforge.net/).
  - Postscript output is not tested because I have issues with the Helvetica font. I think it's doable.
  - PDF output is not tested because it requires the old `PDFlib` extension so there is 0 chances this works (it should be redone in another PR).