### PR TITLE
Port to PHP 8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
     - name: Get source code
       uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
     - name: Get source code
       uses: actions/checkout@v4

--- a/Image/Canvas.php
+++ b/Image/Canvas.php
@@ -150,7 +150,7 @@ class Image_Canvas
      *
      * @abstract
      */
-    function Image_Canvas($params)
+    function __construct($params)
     {
         if (isset($params['left'])) {
             $this->_left = $params['left'];

--- a/Image/Canvas.php
+++ b/Image/Canvas.php
@@ -786,7 +786,7 @@ class Image_Canvas
      *         PEAR_Error on error
      * @static
      */
-    function &factory($canvas, $params)
+    static function &factory($canvas, $params)
     {
         $canvas = strtoupper($canvas);
         

--- a/Image/Canvas/Color.php
+++ b/Image/Canvas/Color.php
@@ -58,7 +58,7 @@ class Image_Canvas_Color extends Image_Color
     * @access public
     * @static
     */
-    function allocateColor(&$img, $color)
+    static function allocateColor(&$img, $color)
     {
         $color = Image_Canvas_Color::color2RGB($color);
 
@@ -81,7 +81,7 @@ class Image_Canvas_Color extends Image_Color
     * @access public
     * @static
     */
-    function color2RGB($color)
+    static function color2RGB($color)
     {
         if (is_array($color)) {
             if (!is_numeric($color[0])) {

--- a/Image/Canvas/GD.php
+++ b/Image/Canvas/GD.php
@@ -151,11 +151,11 @@ class Image_Canvas_GD extends Image_Canvas_WithMap
      *
      * @param array $param Parameter array
      */
-    function Image_Canvas_GD($param)
+    function __construct($param)
     {
         include_once 'Image/Canvas/Color.php';
 
-        parent::Image_Canvas_WithMap($param);
+        parent::__construct($param);
         
         $this->_gd2 = ($this->_version() == 2);
         $this->_pxToPtFactor = ($this->_gd2 ? (72/96) : 1);

--- a/Image/Canvas/GD/JPG.php
+++ b/Image/Canvas/GD/JPG.php
@@ -67,9 +67,9 @@ class Image_Canvas_GD_JPG extends Image_Canvas_GD
      *
      * @param array $param Parameter array
      */
-    function Image_Canvas_GD_JPG($param)
+    function __construct($param)
     {
-        parent::Image_Canvas_GD($param);
+        parent::__construct($param);
         
         if (isset($param['quality'])) {
             $this->_quality = max(0, min(100, $param['quality']));

--- a/Image/Canvas/GD/PNG.php
+++ b/Image/Canvas/GD/PNG.php
@@ -54,9 +54,9 @@ class Image_Canvas_GD_PNG extends Image_Canvas_GD
      *
      * @param array $param Parameter array
      */
-    function Image_Canvas_GD_PNG($param)
+    function __construct($param)
     {
-        parent::Image_Canvas_GD($param);
+        parent::__construct($param);
 
         if ((isset($param['transparent'])) && ($param['transparent'])
             && ($this->_gd2)

--- a/Image/Canvas/ImageMap.php
+++ b/Image/Canvas/ImageMap.php
@@ -369,7 +369,7 @@ class Image_Canvas_ImageMap extends Image_Canvas
     function toHtml($params)
     {
         if (count($this->_map) > 0) {
-            return '<map name="' . $params['name'] . '" id="' . $params['name'] . '">' . "\n\t" . implode($this->_map, "\n\t") . "\n</map>";
+            return '<map name="' . $params['name'] . '" id="' . $params['name'] . '">' . "\n\t" . implode("\n\t", $this->_map) . "\n</map>";
         }
         return ''; 
     }

--- a/Image/Canvas/PDF.php
+++ b/Image/Canvas/PDF.php
@@ -147,7 +147,7 @@ class Image_Canvas_PDF extends Image_Canvas
      *
      * @param array $param Parameter array
      */
-    function Image_Canvas_PDF($param)
+    function __construct($param)
     {
         if (isset($param['page'])) {
             switch (strtoupper($param['page'])) {
@@ -234,7 +234,7 @@ class Image_Canvas_PDF extends Image_Canvas
             $this->_pageHeight = $w;
         }
 
-        parent::Image_Canvas($param);
+        parent::__construct($param);
 
         if (!$this->_pageWidth) {
             $this->_pageWidth = $this->_width;

--- a/Image/Canvas/PS.php
+++ b/Image/Canvas/PS.php
@@ -144,7 +144,7 @@ class Image_Canvas_PS extends Image_Canvas
      *
      * @param array $param Parameter array
      */
-    function Image_Canvas_PS($param)
+    function __construct($param)
     {
         if (isset($param['page'])) {
             switch (strtoupper($param['page'])) {
@@ -233,7 +233,7 @@ class Image_Canvas_PS extends Image_Canvas
             $this->_pageHeight = $w;
         }
 
-        parent::Image_Canvas($param);
+        parent::__construct($param);
 
         if (!$this->_pageWidth) {
             $this->_pageWidth = $this->_width;

--- a/Image/Canvas/SVG.php
+++ b/Image/Canvas/SVG.php
@@ -107,9 +107,9 @@ class Image_Canvas_SVG extends Image_Canvas
      *
      * @return void
      */
-    function Image_Canvas_SVG($params)
+    function __construct($params)
     {
-        parent::Image_Canvas($params);
+        parent::__construct($params);
         $this->_reset();
 
         if (isset($params['encoding'])) {

--- a/Image/Canvas/SWF.php
+++ b/Image/Canvas/SWF.php
@@ -88,9 +88,9 @@ class Image_Canvas_SWF extends Image_Canvas
      *
      * @return Image_Canvas_SWF
      */
-    function Image_Canvas_SWF($params)
+    function __construct($params)
     {
-        parent::Image_Canvas($params);
+        parent::__construct($params);
         $this->_reset();
 
         $version = (isset($params['version']) && $params['version'] <= 6)

--- a/Image/Canvas/Tool.php
+++ b/Image/Canvas/Tool.php
@@ -69,7 +69,7 @@ class Image_Canvas_Tool
      * @return string The filename of the font
      * @static
      */
-    function fontMap($name, $type = '.ttf')
+    static function fontMap($name, $type = '.ttf')
     {
         static $_fontMap;
         
@@ -126,7 +126,7 @@ class Image_Canvas_Tool
      * @return double The average of P1 and P2
      * @static
      */
-    function mid($p1, $p2)
+    static function mid($p1, $p2)
     {
         return ($p1 + $p2) / 2;
     }
@@ -142,7 +142,7 @@ class Image_Canvas_Tool
      * @return double $p1 mirrored in $p2 by Factor
      * @static
      */
-    function mirror($p1, $p2, $factor = 1)
+    static function mirror($p1, $p2, $factor = 1)
     {
         return $p2 + $factor * ($p2 - $p1);
     }
@@ -159,7 +159,7 @@ class Image_Canvas_Tool
      * @return double P1 mirrored in P2 by Factor
      * @static
      */
-    function controlPoint($p1, $p2, $factor, $smoothFactor = 0.75)
+    static function controlPoint($p1, $p2, $factor, $smoothFactor = 0.75)
     {
         $sa = Image_Canvas_Tool::mirror($p1, $p2, $smoothFactor);
         $sb = Image_Canvas_Tool::mid($p2, $sa);
@@ -185,7 +185,7 @@ class Image_Canvas_Tool
      *   $p1 and $p4 to calculate control points
      * @static
      */
-    function bezier($t, $p1, $p2, $p3, $p4)
+    static function bezier($t, $p1, $p2, $p3, $p4)
     {
         // (1-t)^3*p1 + 3*(1-t)^2*t*p2 + 3*(1-t)*t^2*p3 + t^3*p4
         return pow(1 - $t, 3) * $p1 +
@@ -205,7 +205,7 @@ class Image_Canvas_Tool
      * @return double The angle in degrees of the line
      * @static
      */
-    function getAngle($x0, $y0, $x1, $y1)
+    static function getAngle($x0, $y0, $x1, $y1)
     {
         
         $dx = ($x1 - $x0);

--- a/Image/Canvas/WithMap.php
+++ b/Image/Canvas/WithMap.php
@@ -72,9 +72,9 @@ class Image_Canvas_WithMap extends Image_Canvas
      *
      * @abstract
      */
-    function Image_Canvas_WithMap($params)
+    function __construct($params)
     {
-        parent::Image_Canvas($params);
+        parent::__construct($params);
                 
         if ((isset($params['usemap'])) && ($params['usemap'] === true)) {
             $this->_imageMap =& Image_Canvas::factory(

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=5.6",
         "pear/pear_exception": "*",
-        "pear/image_color": "dev-port_php8"
+        "pear/image_color": "dev-master"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,6 @@
     "require": {
         "php": ">=5.6",
         "pear/pear_exception": "*",
-        "pear/image_color": "dev-master"
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url":  "git@github.com:duboism/image_color"
-        }
-    ]
+        "pear/image_color": "*"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,12 @@
     "require": {
         "php": ">=5.6",
         "pear/pear_exception": "*",
-        "pear/image_color": "*"
-    }
+        "pear/image_color": "dev-port_php8"
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url":  "git@github.com:duboism/image_color"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "type": "library",
     "require": {
-        "php": ">=5.6, < 8.0",
+        "php": ">=5.6",
         "pear/pear_exception": "*",
         "pear/image_color": "*"
     }


### PR DESCRIPTION
This PR ports the code to PHP 8 (including PHP 8.4).

~**For now we use the master branch of Image_Color from https://github.com/duboism/Image_Canvas/ because we need a version that runs on PHP 8. This has to be changed before merging.**~ This was changed in [3b4d483](https://github.com/pear/Image_Canvas/pull/7/commits/3b4d4837c0c70b416ef6a26aa3bb10f90e6ec447).

# What was changed

  - correct constructor
  - several functions have been declared static
  - correct a call to `implode`

