### PR TITLE
Allow to run the test suite without composer install

### DIFF
--- a/tests/gradients.php
+++ b/tests/gradients.php
@@ -27,7 +27,13 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */  
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory(
     'png', 

--- a/tests/imagemap.php
+++ b/tests/imagemap.php
@@ -27,7 +27,14 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */  
 
-require_once 'vendor/autoload.php';
+
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory(
     'png', 

--- a/tests/jpg.php
+++ b/tests/jpg.php
@@ -30,7 +30,13 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory('jpg', array('width' => 600, 'height' => 600, 'quality' => 90));
 

--- a/tests/lineends.php
+++ b/tests/lineends.php
@@ -27,7 +27,13 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $font = array('name' => 'Verdana', 'size' => 10);
 

--- a/tests/pdf.php
+++ b/tests/pdf.php
@@ -30,7 +30,13 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory('pdf', array('page' => 'A4', 'align' => 'center', 'width' => 600, 'height' => 600));
 

--- a/tests/png.php
+++ b/tests/png.php
@@ -30,7 +30,13 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory('png', array('width' => 600, 'height' => 600));
 

--- a/tests/ps.php
+++ b/tests/ps.php
@@ -30,7 +30,13 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory('ps', array('page' => 'A4', 'align' => 'center', 'width' => 600, 'height' => 600, 'filename'=>'testps.ps'));
 

--- a/tests/svg.php
+++ b/tests/svg.php
@@ -30,7 +30,13 @@
 // SPECIFY HERE WHERE A TRUETYPE FONT CAN BE FOUND
 $testFont = 'c:/windows/fonts/Arial.ttf';
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory('svg', array('width' => 600, 'height' => 600));
 

--- a/tests/text.php
+++ b/tests/text.php
@@ -27,7 +27,13 @@
  * @link      http://pear.php.net/package/Image_Canvas
  */
 
-require_once 'vendor/autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    // use composer if available
+    require_once 'vendor/autoload.php';
+} else {
+    // otherwise rely on classic PEAR include_path
+    require_once 'Image/Canvas.php';
+}
 
 $canvas =& Image_Canvas::factory(
     'png',


### PR DESCRIPTION
This PR addresses a comment by @ashnazg in #6 : to be able to run the test suite without composer install, we fall back to PEAR-style require if `autoload.php` is not present 